### PR TITLE
Fix: Add hint to show contributors direction on the contributing guidelines page

### DIFF
--- a/doc/contributors-guide/contributing-guidelines.md
+++ b/doc/contributors-guide/contributing-guidelines.md
@@ -1,5 +1,11 @@
 # ℹ Contributing guidelines
 
+{% hint style="info" %}
+"Hi there :wave: Thank you for your interest to contribute to the Git and Github training resource".
+To find guidelines for contributing to the training resource, to know more follow the links below.
+{% endhint %}
+
+
 {% embed url="https://github.com/Ifycode/git-github-training-resource/blob/develop/code_of_conduct.md" %}
 
 {% content-ref url="making-and-submitting-changes.md" %}

--- a/doc/contributors-guide/contributing-guidelines.md
+++ b/doc/contributors-guide/contributing-guidelines.md
@@ -1,12 +1,9 @@
 # ℹ Contributing guidelines
 
 {% hint style="info" %}
-Hi there wave Thank you for your interest to contribute to the [Git and Github training resource](https://obiagba-mary.gitbook.io/git-and-github-training/contributors-guide/contributing-guidelines).
+Hi there 👋 Thank you for your interest to contribute to the [Git and Github training resource](https://obiagba-mary.gitbook.io/git-and-github-training/contributors-guide/contributing-guidelines).
 Find the guidelines for contributing to the training resource in the links below.
 {% endhint %}
-
-https://obiagba-mary.gitbook.io/git-and-github-training/contributors-guide/contributing-guidelines
-
 
 {% embed url="https://github.com/Ifycode/git-github-training-resource/blob/develop/code_of_conduct.md" %}
 

--- a/doc/contributors-guide/contributing-guidelines.md
+++ b/doc/contributors-guide/contributing-guidelines.md
@@ -1,9 +1,11 @@
 # ℹ Contributing guidelines
 
 {% hint style="info" %}
-"Hi there :wave: Thank you for your interest to contribute to the Git and Github training resource".
-To find guidelines for contributing to the training resource, to know more follow the links below.
+Hi there wave Thank you for your interest to contribute to the [Git and Github training resource](https://obiagba-mary.gitbook.io/git-and-github-training/contributors-guide/contributing-guidelines).
+Find the guidelines for contributing to the training resource in the links below.
 {% endhint %}
+
+https://obiagba-mary.gitbook.io/git-and-github-training/contributors-guide/contributing-guidelines
 
 
 {% embed url="https://github.com/Ifycode/git-github-training-resource/blob/develop/code_of_conduct.md" %}


### PR DESCRIPTION
**This pull request makes the following changes:**
* [Add hint to show contributors direction on the contributing guidelines page #66](https://github.com/Ifycode/git-github-training-resource/issues/66).
* Change file `contributors-guide/contributing-guidelines.md`.
  - Add the text for help new contributors.
  - Add link [Git and Github training resource](https://obiagba-mary.gitbook.io/git-and-github-training/contributors-guide/contributing-guidelines).

**Checklist:**
- [x] File or folder now contains changes as specified in the issue i worked on
- [x] I have linked the issue I worked on to this pull request submitted by me
- [x] I certify that I ran my checklist.

Ping @Ifycode/git-github-training-resource
