### PR TITLE
Fix: Help contributors easily find the contributors guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,3 @@
+# Contributing Guidelines
+
+The contributing guidelines can be found on the [contributing guidelines page](https://obiagba-mary.gitbook.io/git-and-github-training/contributors-guide/contributing-guidelines) of the git and Github training gitbook learning resource.


### PR DESCRIPTION
**This pull request makes the following changes:**
Added CONTRIBUTING.md

* Fixes issue #69 

Added CONTRIBUTING.md that lets the reader know that the contributing guidelines can be found on the [contributing guidelines page](https://obiagba-mary.gitbook.io/git-and-github-training/contributors-guide/contributing-guidelines) of the git and Github training gitbook learning resource.


**Checklist:**
- [x] File or folder now contains changes as specified in the issue I worked on
- [x] I have linked the issue I worked on to this pull request submitted by me
- [x] I certify that I ran my checklist.

Ping @Ifycode/git-github-training-resource
